### PR TITLE
fix: colours in `diff` codeblock

### DIFF
--- a/palette/package-lock.json
+++ b/palette/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@catppuccin/highlightjs": "^0.1.2",
+        "@catppuccin/highlightjs": "^0.1.3",
         "@catppuccin/palette": "^0.1.6",
         "sass": "^1.58.3"
       }
     },
     "node_modules/@catppuccin/highlightjs": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@catppuccin/highlightjs/-/highlightjs-0.1.2.tgz",
-      "integrity": "sha512-QbNIkD6fI7ZLY4f6GRUX3DK8HxiuwSkIIYFqAjLu9XKIA11yWtHkWGKUbfLueYeguUQovq1+wufQ3+8iILepzQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@catppuccin/highlightjs/-/highlightjs-0.1.3.tgz",
+      "integrity": "sha512-NpC67ktdwR2nvGYb18uuMU8QDrwL+NUZJ3hMqhyRmVLAr9xJcuFOcDluJAKE3V13xD95aHTaIvyEW6PiWlaQwA==",
       "dev": true,
       "funding": [
         {

--- a/palette/package.json
+++ b/palette/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Soothing pastel theme for mdBook",
   "scripts": {
-    "build": "sass -I node_modules --no-charset --no-source-map .:../src/bin/assets"
+    "build": "sass -I node_modules --no-charset --no-source-map catppuccin.scss:../src/bin/assets/catppuccin.css catppuccin-admonish.scss:../src/bin/assets/catppuccin-admonish.css"
   },
   "repository": {
     "type": "git",

--- a/palette/package.json
+++ b/palette/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/catppuccin/mdBook#readme",
   "devDependencies": {
-    "@catppuccin/highlightjs": "^0.1.2",
+    "@catppuccin/highlightjs": "^0.1.3",
     "@catppuccin/palette": "^0.1.6",
     "sass": "^1.58.3"
   }

--- a/palette/package.json
+++ b/palette/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Soothing pastel theme for mdBook",
   "scripts": {
-    "build": "sass -I node_modules --no-charset --no-source-map catppuccin.scss:../src/bin/assets/catppuccin.css catppuccin-admonish.scss:../src/bin/assets/catppuccin-admonish.css"
+    "build": "sass -I node_modules --no-charset --no-source-map .:../src/bin/assets"
   },
   "repository": {
     "type": "git",

--- a/src/bin/assets/catppuccin.css
+++ b/src/bin/assets/catppuccin.css
@@ -132,11 +132,11 @@
 .mocha .hljs-template-variable {
   color: #f2cdcd;
 }
-.mocha .hljs-diff-addition {
+.mocha .hljs-addition {
   color: #a6e3a1;
   background: rgba(166, 227, 161, 0.15);
 }
-.mocha .hljs-diff-deletion {
+.mocha .hljs-deletion {
   color: #f38ba8;
   background: rgba(243, 139, 168, 0.15);
 }
@@ -294,11 +294,11 @@
 .macchiato .hljs-template-variable {
   color: #f0c6c6;
 }
-.macchiato .hljs-diff-addition {
+.macchiato .hljs-addition {
   color: #a6da95;
   background: rgba(166, 218, 149, 0.15);
 }
-.macchiato .hljs-diff-deletion {
+.macchiato .hljs-deletion {
   color: #ed8796;
   background: rgba(237, 135, 150, 0.15);
 }
@@ -456,11 +456,11 @@
 .frappe .hljs-template-variable {
   color: #eebebe;
 }
-.frappe .hljs-diff-addition {
+.frappe .hljs-addition {
   color: #a6d189;
   background: rgba(166, 209, 137, 0.15);
 }
-.frappe .hljs-diff-deletion {
+.frappe .hljs-deletion {
   color: #e78284;
   background: rgba(231, 130, 132, 0.15);
 }
@@ -618,11 +618,11 @@
 .latte .hljs-template-variable {
   color: #dd7878;
 }
-.latte .hljs-diff-addition {
+.latte .hljs-addition {
   color: #40a02b;
   background: rgba(64, 160, 43, 0.15);
 }
-.latte .hljs-diff-deletion {
+.latte .hljs-deletion {
   color: #d20f39;
   background: rgba(210, 15, 57, 0.15);
 }


### PR DESCRIPTION
Hello!!
I always use mdbook-catppuccin! 🐈‍⬛

After updating to `v1.0.0`, I noticed that the color theme is not applied correctly to the `diff`.

All we are doing in this PR is reverting the parameters related to diffs back to what they were before `v1.0.0`, but I think this will fix this issue.

Could you please confirm this?

Thanks!! ☕