### PR TITLE
fix(admonish): prefix `admonish-` to class names

### DIFF
--- a/palette/catppuccin-admonish.scss
+++ b/palette/catppuccin-admonish.scss
@@ -16,51 +16,51 @@
 
 $mappings: (
   "yellow": (
-    ".hint",
-    ".important",
-    ".tip",
+    ".admonish-hint",
+    ".admonish-important",
+    ".admonish-tip",
   ),
   "flamingo": (
-    ".abstract",
-    ".summary",
-    ".tldr",
+    ".admonish-abstract",
+    ".admonish-summary",
+    ".admonish-tldr",
   ),
   "mauve": (
-    ".example",
+    ".admonish-example",
   ),
   "sky": (
-    ".info",
-    ".todo",
+    ".admonish-info",
+    ".admonish-todo",
   ),
   "green": (
-    ".check",
-    ".done",
-    ".success",
+    ".admonish-check",
+    ".admonish-done",
+    ".admonish-success",
   ),
   "blue": (
-    ".note",
+    ".admonish-note",
   ),
   "peach": (
-    ".attention",
-    ".caution",
-    ".warning",
+    ".admonish-attention",
+    ".admonish-caution",
+    ".admonish-warning",
   ),
   "teal": (
-    ".faq",
-    ".help",
-    ".question",
+    ".admonish-faq",
+    ".admonish-help",
+    ".admonish-question",
   ),
   "red": (
-    ".bug",
-    ".danger",
-    ".error",
-    ".fail",
-    ".failure",
-    ".missing",
+    ".admonish-bug",
+    ".admonish-danger",
+    ".admonish-error",
+    ".admonish-fail",
+    ".admonish-failure",
+    ".admonish-missing",
   ),
   "pink": (
-    ".cite",
-    ".quote",
+    ".admonish-cite",
+    ".admonish-quote",
   ),
 );
 

--- a/src/bin/assets/catppuccin-admonish.css
+++ b/src/bin/assets/catppuccin-admonish.css
@@ -1,363 +1,363 @@
-.mocha :is(.admonition):is(.hint, .important, .tip) {
+.mocha :is(.admonition):is(.admonish-hint, .admonish-important, .admonish-tip) {
   border-color: #f9e2af;
 }
-.mocha :is(.hint, .important, .tip) > :is(.admonition-title, summary.admonition-title) {
+.mocha :is(.admonish-hint, .admonish-important, .admonish-tip) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(249, 226, 175, 0.2);
 }
-.mocha :is(.hint, .important, .tip) > :is(.admonition-title, summary.admonition-title)::before {
+.mocha :is(.admonish-hint, .admonish-important, .admonish-tip) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #f9e2af;
 }
-.mocha :is(.admonition):is(.abstract, .summary, .tldr) {
+.mocha :is(.admonition):is(.admonish-abstract, .admonish-summary, .admonish-tldr) {
   border-color: #f2cdcd;
 }
-.mocha :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary.admonition-title) {
+.mocha :is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(242, 205, 205, 0.2);
 }
-.mocha :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary.admonition-title)::before {
+.mocha :is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #f2cdcd;
 }
-.mocha :is(.admonition):is(.example) {
+.mocha :is(.admonition):is(.admonish-example) {
   border-color: #cba6f7;
 }
-.mocha :is(.example) > :is(.admonition-title, summary.admonition-title) {
+.mocha :is(.admonish-example) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(203, 166, 247, 0.2);
 }
-.mocha :is(.example) > :is(.admonition-title, summary.admonition-title)::before {
+.mocha :is(.admonish-example) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #cba6f7;
 }
-.mocha :is(.admonition):is(.info, .todo) {
+.mocha :is(.admonition):is(.admonish-info, .admonish-todo) {
   border-color: #89dceb;
 }
-.mocha :is(.info, .todo) > :is(.admonition-title, summary.admonition-title) {
+.mocha :is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(137, 220, 235, 0.2);
 }
-.mocha :is(.info, .todo) > :is(.admonition-title, summary.admonition-title)::before {
+.mocha :is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #89dceb;
 }
-.mocha :is(.admonition):is(.check, .done, .success) {
+.mocha :is(.admonition):is(.admonish-check, .admonish-done, .admonish-success) {
   border-color: #a6e3a1;
 }
-.mocha :is(.check, .done, .success) > :is(.admonition-title, summary.admonition-title) {
+.mocha :is(.admonish-check, .admonish-done, .admonish-success) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(166, 227, 161, 0.2);
 }
-.mocha :is(.check, .done, .success) > :is(.admonition-title, summary.admonition-title)::before {
+.mocha :is(.admonish-check, .admonish-done, .admonish-success) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #a6e3a1;
 }
-.mocha :is(.admonition):is(.note) {
+.mocha :is(.admonition):is(.admonish-note) {
   border-color: #89b4fa;
 }
-.mocha :is(.note) > :is(.admonition-title, summary.admonition-title) {
+.mocha :is(.admonish-note) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(137, 180, 250, 0.2);
 }
-.mocha :is(.note) > :is(.admonition-title, summary.admonition-title)::before {
+.mocha :is(.admonish-note) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #89b4fa;
 }
-.mocha :is(.admonition):is(.attention, .caution, .warning) {
+.mocha :is(.admonition):is(.admonish-attention, .admonish-caution, .admonish-warning) {
   border-color: #fab387;
 }
-.mocha :is(.attention, .caution, .warning) > :is(.admonition-title, summary.admonition-title) {
+.mocha :is(.admonish-attention, .admonish-caution, .admonish-warning) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(250, 179, 135, 0.2);
 }
-.mocha :is(.attention, .caution, .warning) > :is(.admonition-title, summary.admonition-title)::before {
+.mocha :is(.admonish-attention, .admonish-caution, .admonish-warning) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #fab387;
 }
-.mocha :is(.admonition):is(.faq, .help, .question) {
+.mocha :is(.admonition):is(.admonish-faq, .admonish-help, .admonish-question) {
   border-color: #94e2d5;
 }
-.mocha :is(.faq, .help, .question) > :is(.admonition-title, summary.admonition-title) {
+.mocha :is(.admonish-faq, .admonish-help, .admonish-question) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(148, 226, 213, 0.2);
 }
-.mocha :is(.faq, .help, .question) > :is(.admonition-title, summary.admonition-title)::before {
+.mocha :is(.admonish-faq, .admonish-help, .admonish-question) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #94e2d5;
 }
-.mocha :is(.admonition):is(.bug, .danger, .error, .fail, .failure, .missing) {
+.mocha :is(.admonition):is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) {
   border-color: #f38ba8;
 }
-.mocha :is(.bug, .danger, .error, .fail, .failure, .missing) > :is(.admonition-title, summary.admonition-title) {
+.mocha :is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(243, 139, 168, 0.2);
 }
-.mocha :is(.bug, .danger, .error, .fail, .failure, .missing) > :is(.admonition-title, summary.admonition-title)::before {
+.mocha :is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #f38ba8;
 }
-.mocha :is(.admonition):is(.cite, .quote) {
+.mocha :is(.admonition):is(.admonish-cite, .admonish-quote) {
   border-color: #f5c2e7;
 }
-.mocha :is(.cite, .quote) > :is(.admonition-title, summary.admonition-title) {
+.mocha :is(.admonish-cite, .admonish-quote) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(245, 194, 231, 0.2);
 }
-.mocha :is(.cite, .quote) > :is(.admonition-title, summary.admonition-title)::before {
+.mocha :is(.admonish-cite, .admonish-quote) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #f5c2e7;
 }
 
-.macchiato :is(.admonition):is(.hint, .important, .tip) {
+.macchiato :is(.admonition):is(.admonish-hint, .admonish-important, .admonish-tip) {
   border-color: #eed49f;
 }
-.macchiato :is(.hint, .important, .tip) > :is(.admonition-title, summary.admonition-title) {
+.macchiato :is(.admonish-hint, .admonish-important, .admonish-tip) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(238, 212, 159, 0.2);
 }
-.macchiato :is(.hint, .important, .tip) > :is(.admonition-title, summary.admonition-title)::before {
+.macchiato :is(.admonish-hint, .admonish-important, .admonish-tip) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #eed49f;
 }
-.macchiato :is(.admonition):is(.abstract, .summary, .tldr) {
+.macchiato :is(.admonition):is(.admonish-abstract, .admonish-summary, .admonish-tldr) {
   border-color: #f0c6c6;
 }
-.macchiato :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary.admonition-title) {
+.macchiato :is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(240, 198, 198, 0.2);
 }
-.macchiato :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary.admonition-title)::before {
+.macchiato :is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #f0c6c6;
 }
-.macchiato :is(.admonition):is(.example) {
+.macchiato :is(.admonition):is(.admonish-example) {
   border-color: #c6a0f6;
 }
-.macchiato :is(.example) > :is(.admonition-title, summary.admonition-title) {
+.macchiato :is(.admonish-example) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(198, 160, 246, 0.2);
 }
-.macchiato :is(.example) > :is(.admonition-title, summary.admonition-title)::before {
+.macchiato :is(.admonish-example) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #c6a0f6;
 }
-.macchiato :is(.admonition):is(.info, .todo) {
+.macchiato :is(.admonition):is(.admonish-info, .admonish-todo) {
   border-color: #91d7e3;
 }
-.macchiato :is(.info, .todo) > :is(.admonition-title, summary.admonition-title) {
+.macchiato :is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(145, 215, 227, 0.2);
 }
-.macchiato :is(.info, .todo) > :is(.admonition-title, summary.admonition-title)::before {
+.macchiato :is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #91d7e3;
 }
-.macchiato :is(.admonition):is(.check, .done, .success) {
+.macchiato :is(.admonition):is(.admonish-check, .admonish-done, .admonish-success) {
   border-color: #a6da95;
 }
-.macchiato :is(.check, .done, .success) > :is(.admonition-title, summary.admonition-title) {
+.macchiato :is(.admonish-check, .admonish-done, .admonish-success) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(166, 218, 149, 0.2);
 }
-.macchiato :is(.check, .done, .success) > :is(.admonition-title, summary.admonition-title)::before {
+.macchiato :is(.admonish-check, .admonish-done, .admonish-success) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #a6da95;
 }
-.macchiato :is(.admonition):is(.note) {
+.macchiato :is(.admonition):is(.admonish-note) {
   border-color: #8aadf4;
 }
-.macchiato :is(.note) > :is(.admonition-title, summary.admonition-title) {
+.macchiato :is(.admonish-note) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(138, 173, 244, 0.2);
 }
-.macchiato :is(.note) > :is(.admonition-title, summary.admonition-title)::before {
+.macchiato :is(.admonish-note) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #8aadf4;
 }
-.macchiato :is(.admonition):is(.attention, .caution, .warning) {
+.macchiato :is(.admonition):is(.admonish-attention, .admonish-caution, .admonish-warning) {
   border-color: #f5a97f;
 }
-.macchiato :is(.attention, .caution, .warning) > :is(.admonition-title, summary.admonition-title) {
+.macchiato :is(.admonish-attention, .admonish-caution, .admonish-warning) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(245, 169, 127, 0.2);
 }
-.macchiato :is(.attention, .caution, .warning) > :is(.admonition-title, summary.admonition-title)::before {
+.macchiato :is(.admonish-attention, .admonish-caution, .admonish-warning) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #f5a97f;
 }
-.macchiato :is(.admonition):is(.faq, .help, .question) {
+.macchiato :is(.admonition):is(.admonish-faq, .admonish-help, .admonish-question) {
   border-color: #8bd5ca;
 }
-.macchiato :is(.faq, .help, .question) > :is(.admonition-title, summary.admonition-title) {
+.macchiato :is(.admonish-faq, .admonish-help, .admonish-question) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(139, 213, 202, 0.2);
 }
-.macchiato :is(.faq, .help, .question) > :is(.admonition-title, summary.admonition-title)::before {
+.macchiato :is(.admonish-faq, .admonish-help, .admonish-question) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #8bd5ca;
 }
-.macchiato :is(.admonition):is(.bug, .danger, .error, .fail, .failure, .missing) {
+.macchiato :is(.admonition):is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) {
   border-color: #ed8796;
 }
-.macchiato :is(.bug, .danger, .error, .fail, .failure, .missing) > :is(.admonition-title, summary.admonition-title) {
+.macchiato :is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(237, 135, 150, 0.2);
 }
-.macchiato :is(.bug, .danger, .error, .fail, .failure, .missing) > :is(.admonition-title, summary.admonition-title)::before {
+.macchiato :is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #ed8796;
 }
-.macchiato :is(.admonition):is(.cite, .quote) {
+.macchiato :is(.admonition):is(.admonish-cite, .admonish-quote) {
   border-color: #f5bde6;
 }
-.macchiato :is(.cite, .quote) > :is(.admonition-title, summary.admonition-title) {
+.macchiato :is(.admonish-cite, .admonish-quote) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(245, 189, 230, 0.2);
 }
-.macchiato :is(.cite, .quote) > :is(.admonition-title, summary.admonition-title)::before {
+.macchiato :is(.admonish-cite, .admonish-quote) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #f5bde6;
 }
 
-.frappe :is(.admonition):is(.hint, .important, .tip) {
+.frappe :is(.admonition):is(.admonish-hint, .admonish-important, .admonish-tip) {
   border-color: #e5c890;
 }
-.frappe :is(.hint, .important, .tip) > :is(.admonition-title, summary.admonition-title) {
+.frappe :is(.admonish-hint, .admonish-important, .admonish-tip) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(229, 200, 144, 0.2);
 }
-.frappe :is(.hint, .important, .tip) > :is(.admonition-title, summary.admonition-title)::before {
+.frappe :is(.admonish-hint, .admonish-important, .admonish-tip) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #e5c890;
 }
-.frappe :is(.admonition):is(.abstract, .summary, .tldr) {
+.frappe :is(.admonition):is(.admonish-abstract, .admonish-summary, .admonish-tldr) {
   border-color: #eebebe;
 }
-.frappe :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary.admonition-title) {
+.frappe :is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(238, 190, 190, 0.2);
 }
-.frappe :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary.admonition-title)::before {
+.frappe :is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #eebebe;
 }
-.frappe :is(.admonition):is(.example) {
+.frappe :is(.admonition):is(.admonish-example) {
   border-color: #ca9ee6;
 }
-.frappe :is(.example) > :is(.admonition-title, summary.admonition-title) {
+.frappe :is(.admonish-example) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(202, 158, 230, 0.2);
 }
-.frappe :is(.example) > :is(.admonition-title, summary.admonition-title)::before {
+.frappe :is(.admonish-example) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #ca9ee6;
 }
-.frappe :is(.admonition):is(.info, .todo) {
+.frappe :is(.admonition):is(.admonish-info, .admonish-todo) {
   border-color: #99d1db;
 }
-.frappe :is(.info, .todo) > :is(.admonition-title, summary.admonition-title) {
+.frappe :is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(153, 209, 219, 0.2);
 }
-.frappe :is(.info, .todo) > :is(.admonition-title, summary.admonition-title)::before {
+.frappe :is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #99d1db;
 }
-.frappe :is(.admonition):is(.check, .done, .success) {
+.frappe :is(.admonition):is(.admonish-check, .admonish-done, .admonish-success) {
   border-color: #a6d189;
 }
-.frappe :is(.check, .done, .success) > :is(.admonition-title, summary.admonition-title) {
+.frappe :is(.admonish-check, .admonish-done, .admonish-success) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(166, 209, 137, 0.2);
 }
-.frappe :is(.check, .done, .success) > :is(.admonition-title, summary.admonition-title)::before {
+.frappe :is(.admonish-check, .admonish-done, .admonish-success) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #a6d189;
 }
-.frappe :is(.admonition):is(.note) {
+.frappe :is(.admonition):is(.admonish-note) {
   border-color: #8caaee;
 }
-.frappe :is(.note) > :is(.admonition-title, summary.admonition-title) {
+.frappe :is(.admonish-note) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(140, 170, 238, 0.2);
 }
-.frappe :is(.note) > :is(.admonition-title, summary.admonition-title)::before {
+.frappe :is(.admonish-note) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #8caaee;
 }
-.frappe :is(.admonition):is(.attention, .caution, .warning) {
+.frappe :is(.admonition):is(.admonish-attention, .admonish-caution, .admonish-warning) {
   border-color: #ef9f76;
 }
-.frappe :is(.attention, .caution, .warning) > :is(.admonition-title, summary.admonition-title) {
+.frappe :is(.admonish-attention, .admonish-caution, .admonish-warning) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(239, 159, 118, 0.2);
 }
-.frappe :is(.attention, .caution, .warning) > :is(.admonition-title, summary.admonition-title)::before {
+.frappe :is(.admonish-attention, .admonish-caution, .admonish-warning) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #ef9f76;
 }
-.frappe :is(.admonition):is(.faq, .help, .question) {
+.frappe :is(.admonition):is(.admonish-faq, .admonish-help, .admonish-question) {
   border-color: #81c8be;
 }
-.frappe :is(.faq, .help, .question) > :is(.admonition-title, summary.admonition-title) {
+.frappe :is(.admonish-faq, .admonish-help, .admonish-question) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(129, 200, 190, 0.2);
 }
-.frappe :is(.faq, .help, .question) > :is(.admonition-title, summary.admonition-title)::before {
+.frappe :is(.admonish-faq, .admonish-help, .admonish-question) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #81c8be;
 }
-.frappe :is(.admonition):is(.bug, .danger, .error, .fail, .failure, .missing) {
+.frappe :is(.admonition):is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) {
   border-color: #e78284;
 }
-.frappe :is(.bug, .danger, .error, .fail, .failure, .missing) > :is(.admonition-title, summary.admonition-title) {
+.frappe :is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(231, 130, 132, 0.2);
 }
-.frappe :is(.bug, .danger, .error, .fail, .failure, .missing) > :is(.admonition-title, summary.admonition-title)::before {
+.frappe :is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #e78284;
 }
-.frappe :is(.admonition):is(.cite, .quote) {
+.frappe :is(.admonition):is(.admonish-cite, .admonish-quote) {
   border-color: #f4b8e4;
 }
-.frappe :is(.cite, .quote) > :is(.admonition-title, summary.admonition-title) {
+.frappe :is(.admonish-cite, .admonish-quote) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(244, 184, 228, 0.2);
 }
-.frappe :is(.cite, .quote) > :is(.admonition-title, summary.admonition-title)::before {
+.frappe :is(.admonish-cite, .admonish-quote) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #f4b8e4;
 }
 
-.latte :is(.admonition):is(.hint, .important, .tip) {
+.latte :is(.admonition):is(.admonish-hint, .admonish-important, .admonish-tip) {
   border-color: #df8e1d;
 }
-.latte :is(.hint, .important, .tip) > :is(.admonition-title, summary.admonition-title) {
+.latte :is(.admonish-hint, .admonish-important, .admonish-tip) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(223, 142, 29, 0.2);
 }
-.latte :is(.hint, .important, .tip) > :is(.admonition-title, summary.admonition-title)::before {
+.latte :is(.admonish-hint, .admonish-important, .admonish-tip) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #df8e1d;
 }
-.latte :is(.admonition):is(.abstract, .summary, .tldr) {
+.latte :is(.admonition):is(.admonish-abstract, .admonish-summary, .admonish-tldr) {
   border-color: #dd7878;
 }
-.latte :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary.admonition-title) {
+.latte :is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(221, 120, 120, 0.2);
 }
-.latte :is(.abstract, .summary, .tldr) > :is(.admonition-title, summary.admonition-title)::before {
+.latte :is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #dd7878;
 }
-.latte :is(.admonition):is(.example) {
+.latte :is(.admonition):is(.admonish-example) {
   border-color: #8839ef;
 }
-.latte :is(.example) > :is(.admonition-title, summary.admonition-title) {
+.latte :is(.admonish-example) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(136, 57, 239, 0.2);
 }
-.latte :is(.example) > :is(.admonition-title, summary.admonition-title)::before {
+.latte :is(.admonish-example) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #8839ef;
 }
-.latte :is(.admonition):is(.info, .todo) {
+.latte :is(.admonition):is(.admonish-info, .admonish-todo) {
   border-color: #04a5e5;
 }
-.latte :is(.info, .todo) > :is(.admonition-title, summary.admonition-title) {
+.latte :is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(4, 165, 229, 0.2);
 }
-.latte :is(.info, .todo) > :is(.admonition-title, summary.admonition-title)::before {
+.latte :is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #04a5e5;
 }
-.latte :is(.admonition):is(.check, .done, .success) {
+.latte :is(.admonition):is(.admonish-check, .admonish-done, .admonish-success) {
   border-color: #40a02b;
 }
-.latte :is(.check, .done, .success) > :is(.admonition-title, summary.admonition-title) {
+.latte :is(.admonish-check, .admonish-done, .admonish-success) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(64, 160, 43, 0.2);
 }
-.latte :is(.check, .done, .success) > :is(.admonition-title, summary.admonition-title)::before {
+.latte :is(.admonish-check, .admonish-done, .admonish-success) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #40a02b;
 }
-.latte :is(.admonition):is(.note) {
+.latte :is(.admonition):is(.admonish-note) {
   border-color: #1e66f5;
 }
-.latte :is(.note) > :is(.admonition-title, summary.admonition-title) {
+.latte :is(.admonish-note) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(30, 102, 245, 0.2);
 }
-.latte :is(.note) > :is(.admonition-title, summary.admonition-title)::before {
+.latte :is(.admonish-note) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #1e66f5;
 }
-.latte :is(.admonition):is(.attention, .caution, .warning) {
+.latte :is(.admonition):is(.admonish-attention, .admonish-caution, .admonish-warning) {
   border-color: #fe640b;
 }
-.latte :is(.attention, .caution, .warning) > :is(.admonition-title, summary.admonition-title) {
+.latte :is(.admonish-attention, .admonish-caution, .admonish-warning) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(254, 100, 11, 0.2);
 }
-.latte :is(.attention, .caution, .warning) > :is(.admonition-title, summary.admonition-title)::before {
+.latte :is(.admonish-attention, .admonish-caution, .admonish-warning) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #fe640b;
 }
-.latte :is(.admonition):is(.faq, .help, .question) {
+.latte :is(.admonition):is(.admonish-faq, .admonish-help, .admonish-question) {
   border-color: #179299;
 }
-.latte :is(.faq, .help, .question) > :is(.admonition-title, summary.admonition-title) {
+.latte :is(.admonish-faq, .admonish-help, .admonish-question) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(23, 146, 153, 0.2);
 }
-.latte :is(.faq, .help, .question) > :is(.admonition-title, summary.admonition-title)::before {
+.latte :is(.admonish-faq, .admonish-help, .admonish-question) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #179299;
 }
-.latte :is(.admonition):is(.bug, .danger, .error, .fail, .failure, .missing) {
+.latte :is(.admonition):is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) {
   border-color: #d20f39;
 }
-.latte :is(.bug, .danger, .error, .fail, .failure, .missing) > :is(.admonition-title, summary.admonition-title) {
+.latte :is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(210, 15, 57, 0.2);
 }
-.latte :is(.bug, .danger, .error, .fail, .failure, .missing) > :is(.admonition-title, summary.admonition-title)::before {
+.latte :is(.admonish-bug, .admonish-danger, .admonish-error, .admonish-fail, .admonish-failure, .admonish-missing) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #d20f39;
 }
-.latte :is(.admonition):is(.cite, .quote) {
+.latte :is(.admonition):is(.admonish-cite, .admonish-quote) {
   border-color: #ea76cb;
 }
-.latte :is(.cite, .quote) > :is(.admonition-title, summary.admonition-title) {
+.latte :is(.admonish-cite, .admonish-quote) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(234, 118, 203, 0.2);
 }
-.latte :is(.cite, .quote) > :is(.admonition-title, summary.admonition-title)::before {
+.latte :is(.admonish-cite, .admonish-quote) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #ea76cb;
 }


### PR DESCRIPTION
Hi, thanks for the last time!
...but I'm back again after a very short period of time.

I heard that the class names have changed in `mdbook-admonish` v1.13.0.
https://github.com/tommilligan/mdbook-admonish/releases/tag/v1.13.0

This PR is from `npm run build` after updating `catppucin-admonish.scss`.

I tried it on my own project first and it seems to be working.
Hopefully this time it will be smooth and approved in one go 😅