### PR TITLE
ci: build fewer targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       CARGO: cargo
       # When CARGO is set to CROSS, this is set to `--target matrix.target`.
-      TARGET_FLAGS:
+      TARGET_FLAGS: ''
       # When CARGO is set to CROSS, TARGET_DIR includes matrix.target.
       TARGET_DIR: ./target
       # Emit backtraces on panics.
@@ -46,18 +46,11 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - linux-musl
           - linux-gnu
           - linux-arm
           - macos
           - win-msvc
-          - win-gnu
-          - win32-msvc
         include:
-          - build: linux-musl
-            os: ubuntu-22.04
-            rust: nightly
-            target: x86_64-unknown-linux-musl
           - build: linux-gnu
             os: ubuntu-22.04
             rust: nightly
@@ -74,14 +67,6 @@ jobs:
             os: windows-2022
             rust: nightly
             target: x86_64-pc-windows-msvc
-          - build: win-gnu
-            os: windows-2022
-            rust: nightly-x86_64-gnu
-            target: x86_64-pc-windows-gnu
-          - build: win32-msvc
-            os: windows-2022
-            rust: nightly
-            target: i686-pc-windows-msvc
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     env:
       CARGO: cargo
       # When CARGO is set to CROSS, this is set to `--target matrix.target`.
-      TARGET_FLAGS:
+      TARGET_FLAGS: ''
       # When CARGO is set to CROSS, TARGET_DIR includes matrix.target.
       TARGET_DIR: ./target
       # Emit backtraces on panics.
@@ -54,18 +54,11 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - linux-musl
           - linux-gnu
           - linux-arm
           - macos
           - win-msvc
-          - win-gnu
-          - win32-msvc
         include:
-          - build: linux-musl
-            os: ubuntu-22.04
-            rust: nightly
-            target: x86_64-unknown-linux-musl
           - build: linux-gnu
             os: ubuntu-22.04
             rust: nightly
@@ -82,14 +75,6 @@ jobs:
             os: windows-2022
             rust: nightly
             target: x86_64-pc-windows-msvc
-          - build: win-gnu
-            os: windows-2022
-            rust: nightly-x86_64-gnu
-            target: x86_64-pc-windows-gnu
-          - build: win32-msvc
-            os: windows-2022
-            rust: nightly
-            target: i686-pc-windows-msvc
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
This commit removes `linux-musl`, `win-gnu`, and `win32-msvc` from our ci/cd pipeline. By removing these unpopular targets, we are able to reduce compute time and further streamline the pipeline.