### PR TITLE
build(nix): drop macOS native dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,8 @@ serde_json = "1.0.105"
 semver = "1.0.19"
 toml_edit = "0.20.1"
 version-compare = "0.1.1"
+
+[profile.release]
+lto = true
+opt-level = "z"
+strip = true

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,6 @@
       mdbook-catppuccin = pkgs.rustPlatform.buildRustPackage {
         pname = "mdbook-catppuccin";
         inherit version;
-        buildInputs = with pkgs; ([] ++ lib.optionals stdenv.isDarwin [libiconv]);
         src = pkgs.nix-gitignore.gitignoreSource [] ./.;
         cargoLock.lockFile = ./Cargo.lock;
       };
@@ -28,21 +27,18 @@
 
     devShells = forAllSystems (pkgs: rec {
       default = pkgs.mkShell {
-        buildInputs = with pkgs; (
-          [
-            rustc
-            cargo
-            gcc
-            rustfmt
-            clippy
-            rust-analyzer
-            # mdbook
-            mdbook-admonish
-            node2nix
-            nodejs
-          ]
-          ++ lib.optionals stdenv.isDarwin [libiconv]
-        );
+        buildInputs = with pkgs; [
+          rustc
+          cargo
+          gcc
+          rustfmt
+          clippy
+          rust-analyzer
+          # mdbook
+          mdbook-admonish
+          node2nix
+          nodejs
+        ];
         RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
       };
       demo = pkgs.mkShell {


### PR DESCRIPTION
Followup for #79, we no longer need `libiconv`. This should make macOS nix builds faster.
