### PR TITLE
fix: change inline codeblocks from `peach` to `text`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ in step `4.` of the [Usage](#usage) section.
 2. Generate the CSS files:
 
    ```shell
-   cd palette
    pnpm install
    pnpm run build
    ```

--- a/src/catppuccin.scss
+++ b/src/catppuccin.scss
@@ -5,6 +5,17 @@
 @each $flavor, $colors in catppuccin.$palette {
   .#{$flavor} {
     @include hljs.highlights($flavor);
+
+    // Each heading is technically a link but
+    // we don't want to highlight it as `blue`
+    :is(h1, h2, h3, h4, h5, h6) {
+      a code {
+        color: map.get($colors, "text");
+      }
+    }
+    a code {
+      color: map.get($colors, "blue");
+    }
     code {
       color: map.get($colors, "text");
       background: map.get($colors, "mantle");
@@ -50,7 +61,7 @@
     --icons: #{map.get($colors, "overlay0")};
     --icons-hover: #{map.get($colors, "overlay1")};
     --links: #{map.get($colors, "blue")};
-    --inline-code-color: #{map.get($colors, "peach")};
+    --inline-code-color: #{map.get($colors, "text")};
     --theme-popup-bg: #{map.get($colors, "mantle")};
     --theme-popup-border: #{map.get($colors, "overlay0")};
     --theme-hover: #{map.get($colors, "surface0")};


### PR DESCRIPTION
<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/f324721f-362b-41de-8d08-f5670ed6c143" style="max-width: 300px;" alt="Before Image"></td>
        <td><img src="https://github.com/user-attachments/assets/4fc7f2ea-a01d-4bc6-b1b2-527a92a951e3" style="max-width: 300px;" alt="After Image"></td>
    </tr>
</table>

BEGIN_COMMIT_OVERRIDE
fix: change inline codeblocks from `peach` to `text`
fix: preserve links as `blue` inside inline codeblocks
END_COMMIT_OVERRIDE