### PR TITLE
fix: brighter search results border color

### DIFF
--- a/src/catppuccin.scss
+++ b/src/catppuccin.scss
@@ -103,7 +103,7 @@ $filters: (
     --searchbar-fg: #{map.get($colors, "text")};
     --searchbar-shadow-color: #{map.get($colors, "crust")};
     --searchresults-header-fg: #{map.get($colors, "text")};
-    --searchresults-border-color: #{map.get($colors, "surface0")};
+    --searchresults-border-color: #{map.get($colors, "surface2")};
     --searchresults-li-bg: #{map.get($colors, "base")};
     --sidebar-header-border-color: #{map.get($colors, "lavender")};
     --search-mark-bg: #{map.get($colors, "peach")};


### PR DESCRIPTION
If you run a search and look at the results (https://mdbook.catppuccin.com/?search=paragraph), the divider between the search results and the content is very difficult to make out.

| Before | After |
| --- | --- |
| <img width="1612" height="800" alt="CleanShot 2026-04-09 at 17 47 04@2x" src="https://github.com/user-attachments/assets/6163c231-f1d3-40ee-b78c-c0b02c82a6cb" /> | <img width="1606" height="790" alt="CleanShot 2026-04-09 at 17 47 56@2x" src="https://github.com/user-attachments/assets/e13e2857-3acb-4be9-8930-c558a522688e" /> |
